### PR TITLE
fix: support Python 3.14 annotations in assign_attr_with_json

### DIFF
--- a/pyJianYingDraft/util.py
+++ b/pyJianYingDraft/util.py
@@ -35,8 +35,7 @@ def assign_attr_with_json(obj: object, attrs: List[str], json_data: Dict[str, An
     """
     type_hints: Dict[str, Type] = {}
     for cls in obj.__class__.__mro__:
-        if '__annotations__' in cls.__dict__:
-            type_hints.update(cls.__annotations__)
+        type_hints.update(inspect.get_annotations(cls))
 
     for attr in attrs:
         if hasattr(type_hints[attr], 'import_json'):


### PR DESCRIPTION
## Problem

On Python 3.14, saving a draft crashes with KeyError fps inside assign_attr_with_json in pyJianYingDraft/util.py.

Python 3.14 introduced deferred annotation evaluation (PEP 649), which means class-level annotations are no longer automatically stored in cls.__dict__. The existing code relied on this, so type_hints was always empty and any attribute lookup raised a KeyError.

## Fix

Replace the manual __dict__ loop with inspect.get_annotations(cls), which is the correct cross-version API for reading class annotations. inspect was already imported in the file so no new dependency is needed.

## Testing

Verified on Python 3.14.4 (WSL/Ubuntu). Draft creation, add_video, and save_draft all complete successfully after the fix.
