### PR TITLE
docs: fix incorrect path in MCP config example

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -108,9 +108,9 @@ python mcp_server.py # 启动 MCP 协议服务，支持 stdio 通信
     "capcut-api": {
       "command": "python3",
       "args": ["mcp_server.py"],
-      "cwd": "/path/to/CapCutAPI",
+      "cwd": "/path/to/VectCutAPI",
       "env": {
-        "PYTHONPATH": "/path/to/CapCutAPI",
+        "PYTHONPATH": "/path/to/VectCutAPI",
         "DEBUG": "0"
       }
     }

--- a/README.md
+++ b/README.md
@@ -107,9 +107,9 @@ Create or update the `mcp_config.json` configuration file:
     "capcut-api": {
       "command": "python3",
       "args": ["mcp_server.py"],
-      "cwd": "/path/to/CapCutAPI",
+      "cwd": "/path/to/VectCutAPI",
       "env": {
-        "PYTHONPATH": "/path/to/CapCutAPI",
+        "PYTHONPATH": "/path/to/VectCutAPI",
         "DEBUG": "0"
       }
     }


### PR DESCRIPTION
The mcp_config.json example in both README.md and README-zh.md references /path/to/CapCutAPI for the cwd and PYTHONPATH fields, but the project was renamed to VectCutAPI. This fixes both occurrences in both files.