### PR TITLE
Fix material path left blank when local files are passed wFix material path left blank for local files passed without draft_folderithout draf…

### DIFF
--- a/pyJianYingDraft/local_materials.py
+++ b/pyJianYingDraft/local_materials.py
@@ -6,6 +6,11 @@ from typing import Optional, Literal
 from typing import Dict, Any
 import imageio.v2 as imageio
 
+def _is_remote_url(url: str) -> bool:
+    """判断给定的字符串是否是真正的远程 http(s) 资源, 而非本地文件路径"""
+    return url.lower().startswith(("http://", "https://"))
+
+
 class Crop_settings:
     """素材的裁剪设置, 各属性均在0-1之间, 注意素材的坐标原点在左上角"""
 
@@ -105,7 +110,13 @@ class Video_material:
             if not material_name:
                 raise ValueError("使用 remote_url 参数时必须指定 material_name")
             self.remote_url = remote_url
-            self.path = ""  # 远程资源没有本地路径
+            if _is_remote_url(remote_url):
+                self.path = ""  # 远程资源没有本地路径
+            else:
+                # remote_url 实际上是一个本地文件路径（调用方未显式传 path），
+                # 仍然填充可用的本地路径，避免生成 path="" 的损坏草稿
+                local_path = os.path.abspath(remote_url)
+                self.path = local_path if os.path.exists(local_path) else ""
         else:
             # 处理本地文件情况
             path = os.path.abspath(path)
@@ -315,7 +326,15 @@ class Audio_material:
         
         self.material_name = material_name if material_name else (os.path.basename(path) if path else "unknown")
         self.material_id = uuid.uuid3(uuid.NAMESPACE_DNS, self.material_name).hex
-        self.path = path if path else ""
+        if path:
+            self.path = path
+        elif remote_url and not _is_remote_url(remote_url):
+            # remote_url 实际上是一个本地文件路径（调用方未显式传 path），
+            # 仍然填充可用的本地路径，避免生成 path="" 的损坏草稿
+            local_path = os.path.abspath(remote_url)
+            self.path = local_path if os.path.exists(local_path) else ""
+        else:
+            self.path = ""
         self.replace_path = replace_path
         self.remote_url = remote_url
         

--- a/save_draft_impl.py
+++ b/save_draft_impl.py
@@ -105,9 +105,10 @@ def save_draft_background(draft_id, draft_folder, task_id):
             for audio in audios:
                 remote_url = audio.remote_url
                 material_name = audio.material_name
-                # Use helper function to build path
-                if draft_folder:
-                    audio.replace_path = build_asset_path(draft_folder, draft_id, "audio", material_name)
+                # Use helper function to build path. This must match output_base_dir
+                # (which falls back to current_dir), since that's where the file is
+                # actually downloaded/copied to below, regardless of draft_folder.
+                audio.replace_path = build_asset_path(output_base_dir, draft_id, "audio", material_name)
                 if not remote_url:
                     logger.warning(f"Audio file {material_name} has no remote_url, skipping download.")
                     continue
@@ -128,9 +129,9 @@ def save_draft_background(draft_id, draft_folder, task_id):
                 material_name = video.material_name
                 
                 if video.material_type == 'photo':
-                    # Use helper function to build path
-                    if draft_folder:
-                        video.replace_path = build_asset_path(draft_folder, draft_id, "image", material_name)
+                    # Use helper function to build path. Must match output_base_dir,
+                    # since that's where the file is actually downloaded/copied to below.
+                    video.replace_path = build_asset_path(output_base_dir, draft_id, "image", material_name)
                     if not remote_url:
                         logger.warning(f"Image file {material_name} has no remote_url, skipping download.")
                         continue
@@ -144,9 +145,9 @@ def save_draft_background(draft_id, draft_folder, task_id):
                     })
                 
                 elif video.material_type == 'video':
-                    # Use helper function to build path
-                    if draft_folder:
-                        video.replace_path = build_asset_path(draft_folder, draft_id, "video", material_name)
+                    # Use helper function to build path. Must match output_base_dir,
+                    # since that's where the file is actually downloaded/copied to below.
+                    video.replace_path = build_asset_path(output_base_dir, draft_id, "video", material_name)
                     if not remote_url:
                         logger.warning(f"Video file {material_name} has no remote_url, skipping download.")
                         continue

--- a/tests/test_local_materials.py
+++ b/tests/test_local_materials.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+
+import pytest
+
+
+def _make_video_file(tmp_path: Path) -> Path:
+    # A tiny valid enough file for os.path.exists()/isfile() checks; the
+    # material construction path we're testing never shells out to ffprobe
+    # because duration/width/height are supplied explicitly.
+    video_path = tmp_path / "clip.mp4"
+    video_path.write_bytes(b"not a real video, just needs to exist")
+    return video_path
+
+
+def test_video_material_local_path_passed_as_remote_url_keeps_usable_path(tmp_path):
+    """Regression test: callers that don't pass draft_folder (e.g. add_video_track)
+    always pass the caller-supplied video_url through as remote_url. When that
+    value is actually a local filesystem path (not http/https), the material
+    must still end up with a usable local `path`, not `path=""`."""
+    from pyJianYingDraft import Video_material
+
+    video_path = _make_video_file(tmp_path)
+
+    material = Video_material(
+        material_type="video",
+        remote_url=str(video_path),
+        material_name="clip.mp4",
+        duration=5.0,
+        width=0,
+        height=0,
+    )
+
+    assert material.path == str(video_path.resolve()) or material.path == str(video_path)
+    assert material.remote_url == str(video_path)
+    exported = material.export_json()
+    assert exported["path"] != ""
+    assert exported["remote_url"] == str(video_path)
+
+
+def test_video_material_true_http_remote_url_still_blanks_path():
+    from pyJianYingDraft import Video_material
+
+    material = Video_material(
+        material_type="video",
+        remote_url="https://example.com/video.mp4",
+        material_name="video.mp4",
+        duration=5.0,
+        width=0,
+        height=0,
+    )
+
+    assert material.path == ""
+    exported = material.export_json()
+    assert exported["path"] == ""
+    assert exported["remote_url"] == "https://example.com/video.mp4"
+
+
+def test_video_material_nonexistent_local_path_blanks_path():
+    from pyJianYingDraft import Video_material
+
+    material = Video_material(
+        material_type="video",
+        remote_url=r"C:\definitely\does\not\exist\clip.mp4",
+        material_name="clip.mp4",
+        duration=5.0,
+        width=0,
+        height=0,
+    )
+
+    assert material.path == ""
+
+
+def test_audio_material_local_path_passed_as_remote_url_keeps_usable_path(tmp_path):
+    from pyJianYingDraft import Audio_material
+
+    audio_path = tmp_path / "voice.mp3"
+    audio_path.write_bytes(b"not real audio, just needs to exist")
+
+    material = Audio_material(
+        remote_url=str(audio_path),
+        material_name="voice.mp3",
+        duration=3.0,
+    )
+
+    assert material.path != ""
+    exported = material.export_json()
+    assert exported["path"] != ""
+
+
+def test_audio_material_true_http_remote_url_still_blanks_path():
+    from pyJianYingDraft import Audio_material
+
+    material = Audio_material(
+        remote_url="https://example.com/voice.mp3",
+        material_name="voice.mp3",
+        duration=3.0,
+    )
+
+    assert material.path == ""

--- a/tests/test_save_draft_local_paths.py
+++ b/tests/test_save_draft_local_paths.py
@@ -1,0 +1,105 @@
+import json
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def test_save_draft_sets_replace_path_for_video_without_draft_folder(monkeypatch, tmp_path):
+    """Regression test: save_draft_background always downloads/copies material
+    files into output_base_dir (which falls back to the project directory when
+    draft_folder is None), but replace_path used to only be set `if draft_folder`.
+    That mismatch left material.path == "" in draft_content.json even though the
+    file had actually been copied. replace_path must be set unconditionally so it
+    matches where the file really ends up."""
+    import save_draft_impl
+    from draft_cache import DRAFT_CACHE
+    from draft_profiles import get_draft_profile
+    from save_task_cache import create_task
+
+    draft_id = "draft-no-folder-video"
+    project_dir = Path(save_draft_impl.__file__).resolve().parent
+    project_draft_dir = project_dir / draft_id
+    if project_draft_dir.exists():
+        shutil.rmtree(project_draft_dir)
+
+    source_video = tmp_path / "source.mp4"
+    source_video.write_bytes(b"fake video bytes")
+
+    video_material = SimpleNamespace(
+        remote_url=str(source_video),
+        material_name="clip.mp4",
+        material_type="video",
+        replace_path=None,
+    )
+
+    payload = {"tracks": [], "materials": {}, "duration": 0}
+    script = SimpleNamespace(
+        materials=SimpleNamespace(audios=[], videos=[video_material]),
+        tracks={},
+        dumps=lambda profile=None: json.dumps(payload),
+    )
+    DRAFT_CACHE[draft_id] = script
+    create_task(draft_id)
+
+    monkeypatch.setattr(save_draft_impl, "get_draft_profile", lambda: get_draft_profile("jianying_pro_10"))
+    monkeypatch.setattr(save_draft_impl, "update_media_metadata", lambda script, task_id=None: None)
+    monkeypatch.setattr(save_draft_impl, "IS_UPLOAD_DRAFT", False)
+
+    try:
+        save_draft_impl.save_draft_background(draft_id, None, draft_id)
+
+        expected_replace_path = save_draft_impl.build_asset_path(
+            str(project_dir), draft_id, "video", "clip.mp4"
+        )
+        assert video_material.replace_path == expected_replace_path
+        assert Path(expected_replace_path).exists()
+    finally:
+        if project_draft_dir.exists():
+            shutil.rmtree(project_draft_dir)
+
+
+def test_save_draft_sets_replace_path_for_audio_without_draft_folder(monkeypatch, tmp_path):
+    import save_draft_impl
+    from draft_cache import DRAFT_CACHE
+    from draft_profiles import get_draft_profile
+    from save_task_cache import create_task
+
+    draft_id = "draft-no-folder-audio"
+    project_dir = Path(save_draft_impl.__file__).resolve().parent
+    project_draft_dir = project_dir / draft_id
+    if project_draft_dir.exists():
+        shutil.rmtree(project_draft_dir)
+
+    source_audio = tmp_path / "source.mp3"
+    source_audio.write_bytes(b"fake audio bytes")
+
+    audio_material = SimpleNamespace(
+        remote_url=str(source_audio),
+        material_name="voice.mp3",
+        replace_path=None,
+    )
+
+    payload = {"tracks": [], "materials": {}, "duration": 0}
+    script = SimpleNamespace(
+        materials=SimpleNamespace(audios=[audio_material], videos=[]),
+        tracks={},
+        dumps=lambda profile=None: json.dumps(payload),
+    )
+    DRAFT_CACHE[draft_id] = script
+    create_task(draft_id)
+
+    monkeypatch.setattr(save_draft_impl, "get_draft_profile", lambda: get_draft_profile("jianying_pro_10"))
+    monkeypatch.setattr(save_draft_impl, "update_media_metadata", lambda script, task_id=None: None)
+    monkeypatch.setattr(save_draft_impl, "IS_UPLOAD_DRAFT", False)
+
+    try:
+        save_draft_impl.save_draft_background(draft_id, None, draft_id)
+
+        expected_replace_path = save_draft_impl.build_asset_path(
+            str(project_dir), draft_id, "audio", "voice.mp3"
+        )
+        assert audio_material.replace_path == expected_replace_path
+        assert Path(expected_replace_path).exists()
+    finally:
+        if project_draft_dir.exists():
+            shutil.rmtree(project_draft_dir)


### PR DESCRIPTION
…t_folder

Video_material/Audio_material blanked path="" whenever remote_url was set, even when remote_url was actually a local filesystem path rather than a true http(s) resource - the add_video/add_image/add_audio endpoints always pass the caller's URL through as remote_url. save_draft_background had the same class of bug: it downloads/copies files into output_base_dir (wh## Problem

`add_video_track.py` / `add_image_impl.py` / `add_audio_track.py` always pass the caller's `video_url`/`image_url`/`audio_url` through to `Video_material`/`Audio_material` as `remote_url`, regardless of whether it's a real `http(s)` resource or a local filesystem path.

`Video_material`/`Audio_material` in `pyJianYingDraft/local_materials.py` blanked `self.path = ""` whenever `remote_url` was set, even when it was actually a local path. Separately, `save_draft_background` in `save_draft_impl.py` always downloads/copies material files into `output_base_dir` (which already falls back to the project directory when `draft_folder` is omitted), but only set `replace_path` (the field exported as `path` in the final JSON) `if draft_folder:`. So even though the file was physically copied to disk, the generated draft's `path` field stayed empty whenever `draft_folder` wasn't explicitly passed to `/add_video` and `/save_draft` - CapCut/Jianying then can't locate the media.

## Fix

- `pyJianYingDraft/local_materials.py`: detect when `remote_url` is actually a local path (not `http://`/`https://`) and populate `self.path` with the resolved local path instead of blanking it, for both `Video_material` and `Audio_material`.
- `save_draft_impl.py`: set `replace_path` unconditionally using `output_base_dir` (which already defaults to the project directory), so it always matches where `download_file` actually places the file, whether or not `draft_folder` was passed.

`get_duration_impl.py`'s ffprobe-based duration probing was already unconditional (not gated on `draft_folder`), and `add_sticker_impl.py`/`add_subtitle_impl.py` don't have this pattern - verified, no changes needed there.

## Tests

Added `tests/test_local_materials.py` and `tests/test_save_draft_local_paths.py` covering the local-path-as-`remote_url` case and the save path without `draft_folder`. Full suite passes (14/14).ich already falls back to the project directory) regardless of draft_folder, but only set replace_path (the exported "path" field) when draft_folder was explicitly passed, leaving draft_content.json pointing at path="" even though the file existed on disk.